### PR TITLE
19 - Setup Indexing for US Blogs

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -3,6 +3,8 @@ indices:
   default:
     include:
       - /blogs/**
+    exclude:
+      - '/blogs/fragments/**'
     target: /blogs/query-index.json
     properties:
       type:
@@ -37,7 +39,7 @@ indices:
         value: attribute(el, "content")
       authorUrl:
         select: head > meta[name="author-link"]
-        value: attribute(el, "content")
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
       robots:
         select: head > meta[name="robots"]
         value: attribute(el, "content")


### PR DESCRIPTION
Improvements:
* Make the author link relative
* Exclude any fragments we might add in the `blog` folder from indexing 

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #19 

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023/demo/maximize-efficiency-hyperautomation
- After: https://indexing2--servicenow--hlxsites.hlx.live/blogs/2023/demo/maximize-efficiency-hyperautomation
