### PR TITLE
trivial - Fix section line w/o sidebar

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -344,8 +344,7 @@ main img {
 }
 
 @media (min-width: 900px) {
-  .section > div,
-  .section:first-child::after {
+  .section > div {
     max-width: 1200px;
     margin: auto;
   }
@@ -357,8 +356,18 @@ body:not(.blog-home-page) main .section:first-child::after {
   display: block;
   height: 9px;
   background: url('/images/blog-diagonal-lines.webp') repeat 0 0;
+  margin: 2.4rem auto 3rem;
+  max-width: calc(1200px - 2.4rem);
+}
+
+@media (max-width: 1224px) {
+  body:not(.blog-home-page) main .section:first-child::after {
+    margin: 2.4rem 1.2rem 3rem;
+  }
+}
+
+body:not(.blog-home-page) main.has-sidebar .section:first-child::after {
   margin: 2.4rem 1.2rem 3rem;
-  max-width: 1200px;
 }
 
 main .section.highlight {


### PR DESCRIPTION
This PR fixes the section line when for when there is no sidebar (the implementation with sidebar was working before as well, the examples below are just to show that I'm not breaking that)

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Part of #2 

Test URLs:
Without sidebar:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/author/mary-hain
- After: https://fix-line--servicenow--hlxsites.hlx.live/blogs/author/mary-hain

Above sidebar:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023/demo/maximize-efficiency-hyperautomation
- After: https://fix-line--servicenow--hlxsites.hlx.live/blogs/2023/demo/maximize-efficiency-hyperautomation

Side by side with sidebar:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/topics/ai-and-automation
- After: https://fix-line--servicenow--hlxsites.hlx.live/blogs/topics/ai-and-automation