### PR TITLE
fix - Copyright Spacing from the article text

### DIFF
--- a/blocks/article-copyright/article-copyright.css
+++ b/blocks/article-copyright/article-copyright.css
@@ -1,1 +1,3 @@
-/* empty */
+.article-copyright {
+  margin-top: 2.5rem;
+}


### PR DESCRIPTION
Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023/demo/maximize-efficiency-hyperautomation
- After: https://copyright-spacing--servicenow--hlxsites.hlx.live/blogs/2023/demo/maximize-efficiency-hyperautomation
