### PR TITLE
Optimise Blog List with Lazy Rendering

### DIFF
--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -72,12 +72,26 @@ export default async function decorate(block) {
 
   // render
   block.classList.add(filterKey);
+  const chunks = [];
+  const chunkSize = 50;
+  for (let i = 0; i < blogs.length; i += chunkSize) {
+    chunks.push(blogs.slice(i, i + chunkSize));
+  }
+
   const showDescription = block.classList.contains('show-description');
-  block.append(
-    ul(
-      ...await Promise.all(blogs.map((blog) => renderFilterCard(blog, showDescription))),
-    ),
+  const cardList = ul();
+  block.append(cardList);
+
+  cardList.append(
+    ...(await Promise.all(
+      chunks[0].map((blog) => renderCard(blog, showDescription)),
+    )),
   );
+  for (let i = 1; i < chunks.length; i += 1) {
+    Promise.all(
+      chunks[i].map((blog) => renderCard(blog, showDescription)),
+    ).then((cards) => cardList.append(...cards));
+  }
 
   await cssPromise;
 }

--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -73,7 +73,7 @@ export default async function decorate(block) {
   // render
   block.classList.add(filterKey);
   const chunks = [];
-  const chunkSize = 10;
+  const chunkSize = 50;
   for (let i = 0; i < blogs.length; i += chunkSize) {
     chunks.push(blogs.slice(i, i + chunkSize));
   }

--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -73,7 +73,7 @@ export default async function decorate(block) {
   // render
   block.classList.add(filterKey);
   const chunks = [];
-  const chunkSize = 50;
+  const chunkSize = 20;
   for (let i = 0; i < blogs.length; i += chunkSize) {
     chunks.push(blogs.slice(i, i + chunkSize));
   }

--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -20,7 +20,7 @@ export async function renderFilterCard(post, showDescription) {
     publicationDate = formatDate(date);
   }
 
-  const card = li(await renderCard(post));
+  const card = li(await renderCard(post, false));
   const cardText = card.querySelector('.card-text');
   const cardArrow = span({ class: 'card-arrow' });
   cardArrow.innerHTML = await arrowSvg;

--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -73,7 +73,7 @@ export default async function decorate(block) {
   // render
   block.classList.add(filterKey);
   const chunks = [];
-  const chunkSize = 20;
+  const chunkSize = 10;
   for (let i = 0; i < blogs.length; i += chunkSize) {
     chunks.push(blogs.slice(i, i + chunkSize));
   }

--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -84,12 +84,12 @@ export default async function decorate(block) {
 
   cardList.append(
     ...(await Promise.all(
-      chunks[0].map((blog) => renderCard(blog, showDescription)),
+      chunks[0].map((blog) => renderFilterCard(blog, showDescription)),
     )),
   );
   for (let i = 1; i < chunks.length; i += 1) {
     Promise.all(
-      chunks[i].map((blog) => renderCard(blog, showDescription)),
+      chunks[i].map((blog) => renderFilterCard(blog, showDescription)),
     ).then((cards) => cardList.append(...cards));
   }
 

--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -87,11 +87,11 @@ export default async function decorate(block) {
       chunks[0].map((blog) => renderFilterCard(blog, showDescription)),
     )),
   );
-  for (let i = 1; i < chunks.length; i += 1) {
-    Promise.all(
-      chunks[i].map((blog) => renderFilterCard(blog, showDescription)),
-    ).then((cards) => cardList.append(...cards));
-  }
+  // for (let i = 1; i < chunks.length; i += 1) {
+  //   Promise.all(
+  //     chunks[i].map((blog) => renderFilterCard(blog, showDescription)),
+  //   ).then((cards) => cardList.append(...cards));
+  // }
 
   await cssPromise;
 }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -29,14 +29,14 @@ async function localizedTopic(topic) {
   return topicResponse[getLocale()] || topicResponse['en-US'] || topicResponse.identifier || topic;
 }
 
-export async function renderCard(post) {
+export async function renderCard(post, renderTopic = true) {
   return (
     div({ class: 'card' },
       div({ class: 'card-thumbnail' },
         a({ href: post.path },
           createOptimizedPicture(post.image, post.header),
         ),
-        post.topic ? div({ class: 'topic-tag' }, div(await localizedTopic(post.topic))) : '',
+        renderTopic && post.topic ? div({ class: 'topic-tag' }, div(await localizedTopic(post.topic))) : '',
       ),
       div({ class: 'card-text' },
         h5(post.header),


### PR DESCRIPTION
After importing all ~200 blogs from 2023 and publishing them, the lighthouse score for the page with the 2023 card list dropped because of the TBT spiking.

This PR makes it so that only the first 20 cards are initially rendered and the rest are lazy rendered as the user scrolls to the end of the list.

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023
- After: https://optimise-list--servicenow--hlxsites.hlx.live/blogs/2023
