### PR TITLE
137 - Ordered list styling removes the ordering

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -198,10 +198,6 @@ dl, ol, ul, pre, blockquote {
   margin-bottom: 1em;
 }
 
-main ol, main ul {
-  list-style: unset;
-}
-
 main li {
   font-size: 1.4rem;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #137
Ordered list with numbers (fixed)
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2022/integrating-elevate-customer-loyalty
- After: https://fix-137--servicenow--hlxsites.hlx.live/blogs/2022/integrating-elevate-customer-loyalty

Unordered list with bullets (unchanged)
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2022/welcome-to-knowledge
- After: https://fix-137--servicenow--hlxsites.hlx.live/blogs/2022/welcome-to-knowledge