### PR TITLE
feat: show social share counters in .page and .live domains

### DIFF
--- a/blocks/social-share/social-share.js
+++ b/blocks/social-share/social-share.js
@@ -30,7 +30,7 @@ export default async function decorate(block) {
     loadScript('https://platform-api.sharethis.com/js/sharethis.js#property=5cae6f10a8698b001266ffd9&product=inline-share-buttons');
   }
 
-  if (window.location.origin.endsWith('hlx.live') || window.location.origin.endsWith('hlx.live')) {
+  if (window.location.hostname !== 'www.servicenow.com' && window.location.hostname !== 'localhost') {
     block.dataset.url = `https://www.servicenow.com${window.location.pathname}.html`;
   }
 


### PR DESCRIPTION
The social share counter from the third party library needs the exact url in order to show the counters.
This PR makes it so that the same counter on that's visible on www.servicenow.com is also visible on `.hlx.live` and `.hlx.page`.

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2022/meet-unidos-employee-belonging-group
- After: https://share-counter--servicenow--hlxsites.hlx.live/blogs/2022/meet-unidos-employee-belonging-group
