### PR TITLE
fix - Optimise LCP score in the homepage

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -151,6 +151,16 @@ async function fetchRuleBasedCards(config, cardInfos, idx) {
   ruleHandler(blogs, cardInfos, idx, config);
 }
 
+let waitedForLCP = false;
+async function optimiseLCP(block) {
+  if (waitedForLCP) return;
+
+  if (block.classList.contains('teaser')) {
+    waitedForLCP = true;
+    await waitForEagerImageLoad(block.querySelector('img'));
+  }
+}
+
 export default async function decorate(block) {
   const apis = [];
   const links = [];
@@ -212,7 +222,5 @@ export default async function decorate(block) {
     }
   }));
 
-  if (block.classList.contains('teaser')) {
-    await waitForEagerImageLoad(block.querySelector('img'));
-  }
+  await optimiseLCP(block);
 }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -1,7 +1,7 @@
 import { createOptimizedPicture, readBlockConfig, toClassName } from '../../scripts/aem.js';
 import { a, div, h5 } from '../../scripts/dom-helpers.js';
 import {
-  FILTERS, fetchAPI, getLocaleBlogs, getLocale, getTopicTags,
+  FILTERS, fetchAPI, getLocaleBlogs, getLocale, getTopicTags, getTemplate,
 } from '../../scripts/scripts.js';
 
 const TRENDS_AND_RESEARCH = toClassName('Trends and Research');
@@ -155,7 +155,8 @@ let waitedForLCP = false;
 async function optimiseLCP(block) {
   if (waitedForLCP) return;
 
-  if (block.classList.contains('teaser')) {
+  const template = getTemplate();
+  if (template && template === 'blog-home-page' && block.classList.contains('teaser')) {
     waitedForLCP = true;
     await waitForEagerImageLoad(block.querySelector('img'));
   }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -6,6 +6,20 @@ import {
 
 const TRENDS_AND_RESEARCH = toClassName('Trends and Research');
 
+async function waitForEagerImageLoad(img) {
+  if (!img) return;
+
+  await new Promise((resolve) => {
+    if (img && !img.complete) {
+      img.setAttribute('loading', 'eager');
+      img.addEventListener('load', resolve);
+      img.addEventListener('error', resolve);
+    } else {
+      resolve();
+    }
+  });
+}
+
 export async function fetchHtml(path) {
   const response = await fetch(path);
   if (!response.ok) {
@@ -197,4 +211,8 @@ export default async function decorate(block) {
       block.append(await renderCard(cardInfos[idx]));
     }
   }));
+
+  if (block.classList.contains('teaser')) {
+    await waitForEagerImageLoad(block.querySelector('img'));
+  }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -451,7 +451,7 @@ async function loadEager(doc) {
     await loadEagerBlocks(main);
     await detectSidebar(main);
     document.body.classList.add('appear');
-    if (LCP_WAIT_SKIP_TEMPLATE.includes(getTemplate())) {
+    if (!LCP_WAIT_SKIP_TEMPLATE.includes(getTemplate())) {
       await waitForLCP(LCP_BLOCKS);
     }
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -22,8 +22,15 @@ import {
 import ffetch from './ffetch.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
+const LCP_WAIT_SKIP_TEMPLATE = [
+  'blog-home-page',
+];
 export const serviceNowDefaultOrigin = 'https://www.servicenow.com';
 export const TAGS_QUERY_INDEX = '/blogs/tags.json';
+
+export function getTemplate() {
+  return toClassName(getMetadata('template'));
+}
 
 export async function fetchAPI(path) {
   const response = await fetch(path);
@@ -444,7 +451,9 @@ async function loadEager(doc) {
     await loadEagerBlocks(main);
     await detectSidebar(main);
     document.body.classList.add('appear');
-    await waitForLCP(LCP_BLOCKS);
+    if (LCP_WAIT_SKIP_TEMPLATE.includes(getTemplate())) {
+      await waitForLCP(LCP_BLOCKS);
+    }
   }
 
   try {


### PR DESCRIPTION
The default logic for awaiting the LCP image doesn't work well for blogs home page, as it is waiting for the first image present in the dom to load, which in that case, is in the sidebar. For the best LCP load time, we need to skip that waiting, quickly load the first card teaser and then wait for that image to load.

Before: LCP 1.7 - 2.2. LHS Score 99 - 100.
After: LCP 1.4 - 1.7. LHS Score 100.

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs
- After: https://homepage-lhs--servicenow--hlxsites.hlx.live/blogs
