### PR TITLE
fix - Blog links underline should be closer to the text

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -239,7 +239,7 @@ a:any-link {
   background: linear-gradient(var(--link-background-color),var(--link-background-color)) bottom repeat-x;
   background-size: 0.2rem 0.2rem;
   font-size: inherit;
-  padding-bottom: 0.5rem;
+  padding-bottom: 0.1rem;
   position: relative;
   transition: all .25s ease-out;
 }


### PR DESCRIPTION
Authoring team reported that the link underline is too far from the text. Switching it back to the way it was prior to #104 

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023/maximize-efficiency-hyperautomation
- After: https://fix-links--servicenow--hlxsites.hlx.live/blogs/2023/maximize-efficiency-hyperautomation
