### PR TITLE
fix - exclude drafts folders from indexing

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -13,6 +13,11 @@ indices:
       - '/fr/blogs/fragments/**'
       - '/nl/blogs/fragments/**'
       - '/uk/blogs/fragments/**'
+      - '/blogs/drafts/**'
+      - '/de/blogs/drafts/**'
+      - '/fr/blogs/drafts/**'
+      - '/nl/blogs/drafts/**'
+      - '/uk/blogs/drafts/**'
     target: /blogs/query-index.json
     properties:
       type:


### PR DESCRIPTION
Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023/maximize-efficiency-hyperautomation
- After: https://exclude-drafts--servicenow--hlxsites.hlx.live/blogs/2023/maximize-efficiency-hyperautomation
