### PR TITLE
fix - Locale selection and prefix

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -95,19 +95,19 @@ const LOCALE_INFO = {
     placeholdersPrefix: '/blogs',
   },
   'en-UK': {
-    urlPrefix: 'uk',
+    urlPrefix: '/uk',
     placeholdersPrefix: '/uk/blogs',
   },
   'de-DE': {
-    urlPrefix: 'de',
+    urlPrefix: '/de',
     placeholdersPrefix: '/de/blogs',
   },
   'fr-FR': {
-    urlPrefix: 'fr',
+    urlPrefix: '/fr',
     placeholdersPrefix: '/fr/blogs',
   },
   'nl-NL': {
-    urlPrefix: 'nl',
+    urlPrefix: '/nl',
     placeholdersPrefix: '/nl/blogs',
   },
 };
@@ -120,11 +120,17 @@ export function getLocale() {
   if (document.documentElement.lang) return document.documentElement.lang;
 
   document.documentElement.lang = 'en-US';
+  const localeMeta = getMetadata('locale');
+  if (localeMeta) {
+    document.documentElement.lang = localeMeta;
+    return document.documentElement.lang;
+  }
+
   const segs = window.location.pathname.split('/');
   if (segs && segs.length > 0) {
     // eslint-disable-next-line no-restricted-syntax
     for (const [key, value] of Object.entries(LOCALE_INFO)) {
-      if (value.urlPrefix === segs[1]) {
+      if (value.urlPrefix.replace('/', '') === segs[1]) {
         document.documentElement.lang = key;
         break;
       }


### PR DESCRIPTION
Fix locale selection in the JS:
* use the metadata if available. we normally set it in the bulk metadata.xls on all paths
* fix url prefix so blog header and copyright are correctly retrieved.

Test URLs:
US (blog header has ServiceNow Research)
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023/maximize-efficiency-hyperautomation
- After: https://fix-locale--servicenow--hlxsites.hlx.live/blogs/2023/maximize-efficiency-hyperautomation

UK (blog header has EMEA Insights)
- Before: https://main--servicenow--hlxsites.hlx.live/uk/blogs/2023/uk-i-must-prepare-future-workplace
- After: https://fix-locale--servicenow--hlxsites.hlx.live/uk/blogs/2023/uk-i-must-prepare-future-workplace