### PR TITLE
155 - No category "ServiceNow Research" in homepage and sidebar + Optimise index

### DIFF
--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -3,7 +3,7 @@ import {
 } from '../../scripts/aem.js';
 import {
   BLOG_QUERY_INDEX,
-  FILTERS, formatDate, getLocaleInfo, serviceNowDefaultOrigin,
+  BLOG_FILTERS, formatDate, getLocaleInfo, serviceNowDefaultOrigin,
 } from '../../scripts/scripts.js';
 import {
   a, div, li, span, ul,
@@ -41,10 +41,11 @@ export async function renderFilterCard(post, showDescription) {
   return card;
 }
 
-async function renderChunk(cardList, blogs,  showDescription) {
+async function renderChunk(cardList, blogs, showDescription) {
   let done = false;
-  let chunk = []
-  for (let i = 0; i < 20; i++) {
+  const chunk = [];
+  for (let i = 0; i < 20; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
     const generate = await blogs.next();
     done = generate.done;
     if (done) {
@@ -64,7 +65,7 @@ async function renderChunk(cardList, blogs,  showDescription) {
   const observer = new IntersectionObserver((entries) => {
     if (entries.some((e) => e.isIntersecting)) {
       observer.disconnect();
-      renderChunk(cardList, blogs,  showDescription);
+      renderChunk(cardList, blogs, showDescription);
     }
   });
   observer.observe(cardList.children[cardList.children.length - 1]);
@@ -89,7 +90,7 @@ export default async function decorate(block) {
   }
 
   // get filter function
-  const filter = FILTERS[filterKey];
+  const filter = BLOG_FILTERS[filterKey];
   if (!filter) {
     // eslint-disable-next-line no-console
     console.warn(`no filter function found for '${filterKey}'`);
@@ -97,10 +98,10 @@ export default async function decorate(block) {
   }
 
   // retrieve and filter blog entries
-  let blogs = ffetch(BLOG_QUERY_INDEX)
+  const blogs = ffetch(BLOG_QUERY_INDEX)
     .chunks(250)
     .sheet('blogs')
-    .filter(FILTERS.locale)
+    .filter(BLOG_FILTERS.locale)
     .filter((blog) => filter(filterValue, blog));
 
   // render

--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -89,6 +89,7 @@ export default async function decorate(block) {
 
   // retrieve and filter blog entries
   let blogs = await ffetch(BLOG_QUERY_INDEX)
+    .chunks(10000)
     .sheet('blogs')
     .filter(FILTERS.locale)
     .filter((blog) => filter(filterValue, blog))

--- a/blocks/blog-list/blog-list.js
+++ b/blocks/blog-list/blog-list.js
@@ -2,12 +2,14 @@ import {
   fetchPlaceholders, loadCSS, toCamelCase, toClassName,
 } from '../../scripts/aem.js';
 import {
-  FILTERS, formatDate, getLocaleBlogs, getLocaleInfo, serviceNowDefaultOrigin,
+  BLOG_QUERY_INDEX,
+  FILTERS, formatDate, getLocaleInfo, serviceNowDefaultOrigin,
 } from '../../scripts/scripts.js';
 import {
   a, div, li, span, ul,
 } from '../../scripts/dom-helpers.js';
 import { fetchHtml, renderCard } from '../cards/cards.js';
+import ffetch from '../../scripts/ffetch.js';
 
 const arrowSvg = fetchHtml(`${window.hlx.codeBasePath}/icons/card-arrow.svg`);
 
@@ -86,9 +88,13 @@ export default async function decorate(block) {
   }
 
   // retrieve and filter blog entries
-  let blogs = await getLocaleBlogs();
-  if (!blogs) return;
-  blogs = filter(blogs, filterValue);
+  let blogs = await ffetch(BLOG_QUERY_INDEX)
+    .sheet('blogs')
+    .filter(FILTERS.locale)
+    .filter((blog) => filter(filterValue, blog))
+    .all();
+
+  if (!blogs.length) return;
 
   // render
   block.classList.add(filterKey);

--- a/blocks/blog-topics/blog-topics.js
+++ b/blocks/blog-topics/blog-topics.js
@@ -1,18 +1,16 @@
 import ffetch from '../../scripts/ffetch.js';
-import { BLOG_QUERY_INDEX, getLocale } from '../../scripts/scripts.js';
+import { BLOG_QUERY_INDEX, BLOG_FILTERS } from '../../scripts/scripts.js';
 import { p, a } from '../../scripts/dom-helpers.js';
 
-async function getLocaleTopics() {
-  const locale = getLocale();
-  window.sidebarTopics = ffetch(`${BLOG_QUERY_INDEX}`)
+async function getBlogTopics() {
+  return ffetch(BLOG_QUERY_INDEX)
     .sheet('topics')
-    .filter((entry) => entry.locale === locale)
+    .filter(BLOG_FILTERS.locale)
     .all();
-  return window.sidebarTopics;
 }
 
 export default async function decorate(block) {
-  const blogTopics = await getLocaleTopics();
+  const blogTopics = await getBlogTopics();
   block.append(
     ...blogTopics.map((topic) => (
       p({ class: 'button-container' },

--- a/blocks/blog-years/blog-years.js
+++ b/blocks/blog-years/blog-years.js
@@ -1,14 +1,12 @@
 import ffetch from '../../scripts/ffetch.js';
-import { BLOG_QUERY_INDEX, getLocale } from '../../scripts/scripts.js';
+import { BLOG_QUERY_INDEX, BLOG_FILTERS } from '../../scripts/scripts.js';
 import { p, a } from '../../scripts/dom-helpers.js';
 
 async function getTopicYears() {
-  const locale = getLocale();
-  window.sidebarYears = ffetch(`${BLOG_QUERY_INDEX}`)
+  return ffetch(`${BLOG_QUERY_INDEX}`)
     .sheet('years')
-    .filter((entry) => entry.locale === locale)
+    .filter(BLOG_FILTERS.locale)
     .all();
-  return window.sidebarYears;
 }
 
 export default async function decorate(block) {

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -2,7 +2,7 @@ import { createOptimizedPicture, readBlockConfig, toClassName } from '../../scri
 import { a, div, h5 } from '../../scripts/dom-helpers.js';
 import ffetch from '../../scripts/ffetch.js';
 import {
-  FILTERS, fetchAPI, getLocale, getTopicTags, getTemplate, BLOG_QUERY_INDEX,
+  BLOG_FILTERS, fetchAPI, getLocale, getTopicTags, getTemplate, BLOG_QUERY_INDEX,
 } from '../../scripts/scripts.js';
 
 const TRENDS_AND_RESEARCH = toClassName('Trends and Research');
@@ -96,8 +96,8 @@ function fetchAPIBasedCards(cardInfos, apis) {
 
 async function homepageLatestRule(blogs, cardInfos, idx) {
   cardInfos[idx] = await blogs
-    .filter(FILTERS.locale)
-    .filter((blog) => !FILTERS.category(RESEARCH_CATEGORY, blog))
+    .filter(BLOG_FILTERS.locale)
+    .filter((blog) => !BLOG_FILTERS.category(RESEARCH_CATEGORY, blog))
     .limit(3)
     .all();
 }
@@ -107,26 +107,24 @@ async function homepageCategoryRule(blogs, cardInfos, idx, config) {
     .map((link) => new URL(link.href).pathname);
 
   cardInfos[idx] = await blogs
-    .filter(FILTERS.locale)
-    .filter((blog) => 
-      FILTERS.category(toClassName(config.category), blog) &&
-      !latestLinks.includes(blog.path)
-    )
+    .filter(BLOG_FILTERS.locale)
+    .filter((blog) => BLOG_FILTERS.category(toClassName(config.category), blog)
+      && !latestLinks.includes(blog.path))
     .limit(3)
     .all();
 }
 
 async function sidebarFeaturedRule(blogs, cardInfos, idx) {
   cardInfos[idx] = await blogs
-    .filter(FILTERS.locale)
-    .filter((blog) => !FILTERS.trend(TRENDS_AND_RESEARCH, blog))
+    .filter(BLOG_FILTERS.locale)
+    .filter((blog) => !BLOG_FILTERS.trend(TRENDS_AND_RESEARCH, blog))
     .limit(3)
     .all();
 }
 
 async function sidebarTrendsAndResearchRule(blogs, cardInfos, idx) {
-  cardInfos[idx] = await blogs.filter(FILTERS.locale)
-    .filter((blog) => FILTERS.trend(TRENDS_AND_RESEARCH, blog))
+  cardInfos[idx] = await blogs.filter(BLOG_FILTERS.locale)
+    .filter((blog) => BLOG_FILTERS.trend(TRENDS_AND_RESEARCH, blog))
     .limit(3)
     .all();
 }

--- a/scripts/ffetch.js
+++ b/scripts/ffetch.js
@@ -12,20 +12,31 @@
 
 /* eslint-disable no-restricted-syntax,  no-await-in-loop */
 
+const memoryCache = {};
+
 async function* request(url, context) {
   const { chunkSize, sheetName, fetch } = context;
   for (let offset = 0, total = Infinity; offset < total; offset += chunkSize) {
     const params = new URLSearchParams(`offset=${offset}&limit=${chunkSize}`);
     if (sheetName) params.append('sheet', sheetName);
-    const resp = await fetch(`${url}?${params.toString()}`);
-    if (resp.ok) {
-      const json = await resp.json();
-      total = json.total;
-      context.total = total;
-      for (const entry of json.data) yield entry;
+
+    const requestPath = `${url}?${params.toString()}`;
+    let json = null;
+    if (memoryCache[requestPath]) {
+      json = memoryCache[requestPath];
     } else {
-      return;
+      const resp = await fetch(requestPath);
+      if (resp.ok) {
+        json = await resp.json();
+      }
+      memoryCache[requestPath] = json;
     }
+
+    if (!json) return;
+
+    total = json.total;
+    context.total = total;
+    for (const entry of json.data) yield entry;
   }
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -64,17 +64,6 @@ function buildHeroBlock(main) {
   }
 }
 
-export const FILTERS = {
-  locale: (blog) => getLocale() === blog.locale,
-  trend: (trend, blog) => trend === toClassName(blog.trend),
-  newTrend: (newTrend, blog) => newTrend === toClassName(blog.newTrend),
-  category: (category, blog) => category === toClassName(blog.category),
-  topic: (topic, blog) =>  topic === toClassName(blog.topic),
-  year: (year, blog) => year === blog.year,
-  author: (authorUrl, blog) =>
-    authorUrl === new URL(blog.authorUrl, serviceNowDefaultOrigin).pathname.split('.')[0],
-};
-
 /**
  * load fonts.css and set a session storage flag
  */
@@ -138,6 +127,18 @@ export function getLocale() {
   }
   return document.documentElement.lang;
 }
+
+export const BLOG_FILTERS = {
+  locale: (blog) => getLocale() === blog.locale,
+  trend: (trend, blog) => trend === toClassName(blog.trend),
+  newTrend: (newTrend, blog) => newTrend === toClassName(blog.newTrend),
+  category: (category, blog) => category === toClassName(blog.category),
+  topic: (topic, blog) => topic === toClassName(blog.topic),
+  year: (year, blog) => year === blog.year,
+  author: (authorUrl, blog) => (
+    authorUrl === new URL(blog.authorUrl, serviceNowDefaultOrigin).pathname.split('.')[0]
+  ),
+};
 
 /**
  * Returns the locale information

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -65,14 +65,14 @@ function buildHeroBlock(main) {
 }
 
 export const FILTERS = {
-  trend: (blogs, trend) => blogs.filter((blog) => trend === toClassName(blog.trend)),
-  newTrend: (blogs, newTrend) => blogs.filter((blog) => newTrend === toClassName(blog.newTrend)),
-  category: (blogs, category) => blogs.filter((blog) => category === toClassName(blog.category)),
-  topic: (blogs, topic) => blogs.filter((blog) => topic === toClassName(blog.topic)),
-  year: (blogs, year) => blogs.filter((blog) => year === blog.year),
-  author: (blogs, authorUrl) => blogs.filter(
-    (blog) => authorUrl === new URL(blog.authorUrl, serviceNowDefaultOrigin).pathname.split('.')[0],
-  ),
+  locale: (blog) => getLocale() === blog.locale,
+  trend: (trend, blog) => trend === toClassName(blog.trend),
+  newTrend: (newTrend, blog) => newTrend === toClassName(blog.newTrend),
+  category: (category, blog) => category === toClassName(blog.category),
+  topic: (topic, blog) =>  topic === toClassName(blog.topic),
+  year: (year, blog) => year === blog.year,
+  author: (authorUrl, blog) =>
+    authorUrl === new URL(blog.authorUrl, serviceNowDefaultOrigin).pathname.split('.')[0],
 };
 
 /**
@@ -145,33 +145,6 @@ export function getLocale() {
  */
 export function getLocaleInfo() {
   return LOCALE_INFO[getLocale()] || LOCALE_INFO['en-US'];
-}
-
-/**
- * Retrievs and retuns the list of blogs for the current locale based on the index
- * Read Only: Consumers of this API should not modify the list, as it is cached
- * @returns {Array} array of blog objects
- */
-export async function getLocaleBlogs() {
-  if (window.blogs) return window.blogs;
-
-  const response = await fetchAPI(`${BLOG_QUERY_INDEX}?sheet=blogs&limit=10000`);
-  if (!response) {
-    // eslint-disable-next-line no-console
-    console.warn('failed to retrieve blogs.');
-    return [];
-  }
-
-  const blogs = response.data;
-  if (!blogs) {
-    // eslint-disable-next-line no-console
-    console.warn('failed to retrieve blogs.');
-    return [];
-  }
-
-  const locale = getLocale();
-  window.blogs = blogs.filter((blog) => blog.locale === locale);
-  return window.blogs;
 }
 
 export async function getTopicTags() {


### PR DESCRIPTION
The lighthouse score for the homepage and blog list pages had been declining since we've been importing more blog pages, as the size of the payload being transferred over the network had increased. This PR optimises the access to the index by transferring one chunk at a time, only when needed, instead of bringing all the entries in 1 go.

Additionally:
Fix #155

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs
- After: https://optimise-index--servicenow--hlxsites.hlx.live/blogs

- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023
- After: https://optimise-index--servicenow--hlxsites.hlx.live/blogs/2023
