### PR TITLE
feat - allow switching launch version

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -9,11 +9,23 @@ async function loadAdobeDTM() {
   const prod = 'https://assets.adobedtm.com/a441b904b50e/7a4facbbcffb/launch-039be8795dc8.min.js';
   const stage = 'https://assets.adobedtm.com/a441b904b50e/7a4facbbcffb/launch-a2ae4c3b0523-staging.min.js';
 
+  const searchParams = new URLSearchParams(window.location.search);
+  const env = searchParams.get('launch');
+  if (env === 'prod') {
+    loadScript(prod, { async: '' });
+    return;
+  }
+
+  if (env === 'stage') {
+    loadScript(stage, { async: '' });
+    return;
+  }
+
   const { host } = window.location;
-  if (host === 'servicenow.com' || host === 'www.servicenow.com' || host.endsWith('.live')) {
+  if (host === 'servicenow.com' || host === 'www.servicenow.com') {
     loadScript(prod, { async: '' });
   } else {
-    if (new URLSearchParams(window.location.search).get('disableLaunch') === 'true') {
+    if (searchParams.get('disableLaunch') === 'true') {
       return;
     }
     loadScript(stage, { async: '' });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -49,7 +49,7 @@ export function analyticsGlobalClickTrack(digitalData, event) {
   };
   window.appEventData.push(data);
   // eslint-disable-next-line no-console
-  console.log(JSON.stringify(window.appEventData, undefined, 4));
+  console.log(JSON.stringify(data, undefined, 4));
 }
 
 export async function fetchAPI(path) {


### PR DESCRIPTION
feat: Allow setting the launch version via query parameters.
fix: Set staging launch for hlx URLs (as requested by the customer)

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs
- After: https://launch--servicenow--hlxsites.hlx.live/blogs
