### PR TITLE
fix - Mobile Optimisation for BlogList

### DIFF
--- a/aemeds/blocks/blog-list/blog-list.css
+++ b/aemeds/blocks/blog-list/blog-list.css
@@ -139,6 +139,19 @@
   }
 }
 
+@media (max-width: 480px) {
+  .blog-list .card .card-text {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .blog-list .card .card-text .card-cta {
+    position: static;
+    text-align: right;
+    margin-top: auto;
+  }
+}
+
 @media only screen and (min-width: 1024px) {
   .blog-list .card .card-text .card-cta a .card-arrow {
     margin-left: .5rem;

--- a/aemeds/blocks/blog-list/blog-list.css
+++ b/aemeds/blocks/blog-list/blog-list.css
@@ -149,6 +149,7 @@
     position: static;
     text-align: right;
     margin-top: auto;
+    margin-bottom: 1.5rem;
   }
 }
 

--- a/aemeds/blocks/cards/cards.css
+++ b/aemeds/blocks/cards/cards.css
@@ -69,6 +69,10 @@
   flex: 1 0 auto;
 }
 
+.card .card-text a {
+  background: none;
+}
+
 .card .card-text h5 {
   font-size: 1.8rem;
   line-height: 2.3rem;


### PR DESCRIPTION
On small mobile screens, the read more CTA was getting overlapped with the rest of the text.

<img width="393" alt="Screenshot 2024-01-04 at 10 54 02" src="https://github.com/hlxsites/servicenow/assets/3651689/69cc63e4-e46f-48d3-ae73-a0c0d93d1f1a">

This was also happening on the original website:
<img width="395" alt="Screenshot 2024-01-04 at 10 54 43" src="https://github.com/hlxsites/servicenow/assets/3651689/bbb5e69e-b430-49e7-a59d-835c5abe558d">

This PR addresses this problem for small screens.

<img width="399" alt="Screenshot 2024-01-04 at 11 31 57" src="https://github.com/hlxsites/servicenow/assets/3651689/7faaceb1-604e-4f2f-b985-a73fba2369eb">

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023
- After: https://list-mobile--servicenow--hlxsites.hlx.live/blogs/2023
