### PR TITLE
206 - Adjust GoLive date into the social share component

### DIFF
--- a/aemeds/blocks/social-share/social-share.js
+++ b/aemeds/blocks/social-share/social-share.js
@@ -6,7 +6,7 @@ import {
 } from '../../scripts/scripts.js';
 
 // FIXME: update date before launch
-const esdCutOff = new Date('2024-01-08'); // 8 January 2024
+const esdCutOff = new Date('2024-03-30'); // 30 March 2024
 
 function socialShareTracking(block) {
   block.addEventListener('click', (e) => {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Partial for #206

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2024/fortune-worlds-most-admired-companies
- After: https://socialshare-date--servicenow--hlxsites.hlx.live/blogs/2024/fortune-worlds-most-admired-companies
