### PR TITLE
fix - Header Search Accessibility

### DIFF
--- a/aemeds/blocks/blogheader/blogheader.js
+++ b/aemeds/blocks/blogheader/blogheader.js
@@ -218,7 +218,6 @@ export default async function decorate(block) {
     navSections.appendChild(searchLi);
     navSections.setAttribute('aria-expanded', 'false');
 
-
     const menuText = placeholders.mobileMenu || 'Menu';
     blogHeader.prepend(
       div({

--- a/aemeds/blocks/blogheader/blogheader.js
+++ b/aemeds/blocks/blogheader/blogheader.js
@@ -197,6 +197,8 @@ export default async function decorate(block) {
       }, 350);
     };
 
+    const placeholders = await placeholdersPromise;
+
     const searchLi = li({ class: 'blogsearch-menu-container' },
       div({ class: 'blogsearch' }, form({},
         div({ class: 'search-container' },
@@ -204,6 +206,7 @@ export default async function decorate(block) {
           span({ class: 'search-indicator' }),
           input({
             type: 'text',
+            'aria-label': placeholders.search || 'Search',
             oninput: () => { debouncedSearch(); },
             onkeyup: (e) => { if (e.code === 'Escape') { delayedBlur(); } },
             onblur: () => { delayedBlur(); },
@@ -215,7 +218,6 @@ export default async function decorate(block) {
     navSections.appendChild(searchLi);
     navSections.setAttribute('aria-expanded', 'false');
 
-    const placeholders = await placeholdersPromise;
 
     const menuText = placeholders.mobileMenu || 'Menu';
     blogHeader.prepend(


### PR DESCRIPTION
There was a small penalty in accessibility on desktop, because the search input didn't have an accessible description.

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs
- After: https://search-accessibility--servicenow--hlxsites.hlx.live/blogs
