### PR TITLE
feat: Exclude Current Blog from Sidebar

### DIFF
--- a/aemeds/blocks/cards/cards.js
+++ b/aemeds/blocks/cards/cards.js
@@ -180,6 +180,7 @@ async function sidebarFeaturedRule(blogs, cardInfos, idx) {
   cardInfos[idx] = await blogs
     .filter(BLOG_FILTERS.locale)
     .filter((blog) => !BLOG_FILTERS.trend(TRENDS_AND_RESEARCH, blog))
+    .filter((blog) => blog.path !== window.location.pathname)
     .limit(3)
     .all();
 }
@@ -187,6 +188,7 @@ async function sidebarFeaturedRule(blogs, cardInfos, idx) {
 async function sidebarTrendsAndResearchRule(blogs, cardInfos, idx) {
   cardInfos[idx] = await blogs.filter(BLOG_FILTERS.locale)
     .filter((blog) => BLOG_FILTERS.trend(TRENDS_AND_RESEARCH, blog))
+    .filter((blog) => blog.path !== window.location.pathname)
     .limit(3)
     .all();
 }


### PR DESCRIPTION
The customer mentioned that it is not the best experience for readers to have the currently opened blog in the sidebar.

Test URLs:
Homepage:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs
- After: https://exclude-current--servicenow--hlxsites.hlx.live/blogs

Blog Page:
- Before: https://main--servicenow--hlxsites.hlx.live/
- After: https://exclude-current--servicenow--hlxsites.hlx.live/blogs/2024/fast-time-value-washington-dc-release 