### PR TITLE
fix: VQA Feedback for Cards

### DIFF
--- a/aemeds/blocks/cards/cards.css
+++ b/aemeds/blocks/cards/cards.css
@@ -121,6 +121,7 @@
 
 /* stylelint-disable-next-line no-descending-specificity */
 .cards.sidebar .card {
+  width: 100%;
   padding-bottom: 1.5rem;
   border-bottom: 0.1rem solid #d9d9d9;
 }
@@ -151,7 +152,6 @@
 
 @media (max-width: 480px) {
   .cards.sidebar .card .card-thumbnail {
-    padding-left: 1rem;
     flex: 0 0 auto;
     width: 13.7rem;
     height: 12.7rem;;


### PR DESCRIPTION
Images on mobile in the sidebar cards should be aligned with the section title
Cards separator is too short when there is little text in the card

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs
- After: https://vqa-homepage--servicenow--hlxsites.hlx.live/blogs
