### PR TITLE
fix: Use new brand colors for the brightcove player

### DIFF
--- a/aemeds/blocks/embed/embed.css
+++ b/aemeds/blocks/embed/embed.css
@@ -78,10 +78,13 @@ main .embed.embed-brightcove .video-js .vjs-big-play-button:active,
 main .embed.embed-brightcove .video-js .vjs-big-play-button:focus,
 main .embed.embed-brightcove .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-item.vjs-selected,
 main .embed.embed-brightcove .video-js .vjs-play-progress,
-main .embed.embed-brightcove .video-js .vjs-volume-level,
+main .embed.embed-brightcove .video-js .vjs-volume-level {
+  background-color: var(--arc-color-brandgreen-300);
+}
+
 main .embed.embed-brightcove .video-js:active .vjs-big-play-button,
 main .embed.embed-brightcove .video-js:hover .vjs-big-play-button {
-  background-color: var(--arc-color-brandgreen-300);
+  background-color: var(--arc-color-brandgreen-500);
 }
 
 main .embed.embed-mp4 video {

--- a/aemeds/blocks/embed/embed.css
+++ b/aemeds/blocks/embed/embed.css
@@ -67,6 +67,23 @@ main .embed .embed-placeholder-play button::before {
   padding-bottom: 56.25%;
 }
 
+main .embed.embed-brightcove .video-js .vjs-big-play-button,
+main .embed.embed-brightcove .video-js .vjs-big-play-state.vjs-play-control.vjs-control,
+main .embed.embed-brightcove .video-js .vjs-control-bar {
+  background-color: var(--arc-color-brandblue-900);
+}
+
+main .embed.embed-brightcove .video-js .vjs-playlist-sidebar .vjs-playlist-show-hide button:hover,
+main .embed.embed-brightcove .video-js .vjs-big-play-button:active,
+main .embed.embed-brightcove .video-js .vjs-big-play-button:focus,
+main .embed.embed-brightcove .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-item.vjs-selected,
+main .embed.embed-brightcove .video-js .vjs-play-progress,
+main .embed.embed-brightcove .video-js .vjs-volume-level,
+main .embed.embed-brightcove .video-js:active .vjs-big-play-button,
+main .embed.embed-brightcove .video-js:hover .vjs-big-play-button {
+  background-color: var(--arc-color-brandgreen-300);
+}
+
 main .embed.embed-mp4 video {
   width: 100%;
 }


### PR DESCRIPTION
Customer feedback:
> The video player on this blog is pulling the old brand colors for the play button and the bar across the bottom once the video is playing. Can all videos be updated to reflect the new brand colors? 

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023/what-makes-servicenow-employees-stay
- After: https://bcvplayercolors--servicenow--hlxsites.hlx.live/blogs/2023/what-makes-servicenow-employees-stay
