### PR TITLE
fix: Include card title in the Blog List eVar22

### DIFF
--- a/aemeds/blocks/blog-list/blog-list.js
+++ b/aemeds/blocks/blog-list/blog-list.js
@@ -35,7 +35,7 @@ function clickTrack(card) {
             destination: link.href,
             ctaText,
             pageArea: 'body',
-            section: h1,
+            section: `${h1}:${cardTitle}`,
           },
         },
       }, e);


### PR DESCRIPTION
Fix: The Card title was not being included in the evar22 information being sent when clicking a blog list card.

Test URLs:
With Launch
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/category/company-news
- After: https://listclickfix--servicenow--hlxsites.hlx.live/blogs/category/company-news

Without Launch
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/category/company-news?disableLaunch=true
- After: https://listclickfix--servicenow--hlxsites.hlx.live/blogs/category/company-news?disableLaunch=true