### PR TITLE
test: allow disabling launch in production for 1 page

### DIFF
--- a/head.html
+++ b/head.html
@@ -32,6 +32,11 @@
       "https://assets.adobedtm.com/a441b904b50e/7a4facbbcffb/launch-a2ae4c3b0523-staging.min.js";
 
     const searchParams = new URLSearchParams(window.location.search);
+    if (window.location.pathname === '/blogs/2023/ai-business-process-analyst-role'
+      && searchParams.get("disableLaunch") === "true") {
+      return;
+    }
+
     const env = searchParams.get("launch");
     if (env === "prod") {
       loadScript(prod, { async: "" });


### PR DESCRIPTION
Allow disabling launch in production for 1 page to check performance through the servicenow CDN.

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2023/ai-business-process-analyst-role
- After: https://disablelaunchprod--servicenow--hlxsites.hlx.live/blogs/2023/ai-business-process-analyst-role?disableLaunch=true
