### PR TITLE
fix: Configure Target to not hide the body when loaded

### DIFF
--- a/head.html
+++ b/head.html
@@ -26,6 +26,9 @@
   }
 
   async function loadAdobeDTM() {
+    window.targetGlobalSettings = {
+      bodyHidingEnabled: false,
+    };
     const prod =
       "https://assets.adobedtm.com/a441b904b50e/7a4facbbcffb/launch-039be8795dc8.min.js";
     const stage =

--- a/head.html
+++ b/head.html
@@ -4,6 +4,8 @@
 <link rel="stylesheet" href="/aemeds/styles/styles.css" />
 <script src="/aemeds/scripts/jquery-3.7.1.min.js"></script>
 <link rel="dns-prefetch" href="https://www.servicenow.com/" />
+<!-- To eliminate flicker introduced by Adobe Target-->
+<style id="at-body-style">body {opacity: 1}</style>
 <script>
   async function loadScript(src, attrs) {
     return new Promise((resolve, reject) => {
@@ -26,9 +28,6 @@
   }
 
   async function loadAdobeDTM() {
-    window.targetGlobalSettings = {
-      bodyHidingEnabled: false,
-    };
     const prod =
       "https://assets.adobedtm.com/a441b904b50e/7a4facbbcffb/launch-039be8795dc8.min.js";
     const stage =


### PR DESCRIPTION
Test URLs:
With Launch
- Before: https://main--servicenow--hlxsites.hlx.live/blogs
- After: https://targetflickering--servicenow--hlxsites.hlx.live/blogs

With Launch Disabled
- Before: https://main--servicenow--hlxsites.hlx.live/blogs?disableLaunch=true
- After: https://targetflickering--servicenow--hlxsites.hlx.live/blogs?disableLaunch=true
