### PR TITLE
fix: Soclial Share Click Track

### DIFF
--- a/aemeds/blocks/social-share/social-share.js
+++ b/aemeds/blocks/social-share/social-share.js
@@ -2,7 +2,6 @@ import { loadScript, getMetadata } from '../../scripts/aem.js';
 import {
   analyticsCanonicStr,
   analyticsGlobalClickTrack,
-  getAnalyticsSiteName,
 } from '../../scripts/scripts.js';
 
 // FIXME: update date before launch
@@ -11,6 +10,7 @@ const esdCutOff = new Date('2024-04-16'); // 16 April 2024
 function socialShareTracking(block) {
   block.addEventListener('click', (e) => {
     const button = e.target.parentElement;
+    console.log(button);
 
     if (button.classList.contains('st-btn')) {
       const section = analyticsCanonicStr(document.querySelector('h1')?.textContent);

--- a/aemeds/blocks/social-share/social-share.js
+++ b/aemeds/blocks/social-share/social-share.js
@@ -15,9 +15,8 @@ function socialShareTracking(block) {
     }
     if (!button) return;
 
-    const section = analyticsCanonicStr(document.querySelector('h1')?.textContent);
-    const networkLabel = button.getAttribute('data-network');
-    const ctaText = `sharethis-link:${networkLabel}`;
+    const section = `${analyticsCanonicStr(document.querySelector('h1')?.textContent)}:sharethis-link`;
+    const ctaText = button.getAttribute('data-network');
 
     analyticsGlobalClickTrack({
       event: {

--- a/aemeds/blocks/social-share/social-share.js
+++ b/aemeds/blocks/social-share/social-share.js
@@ -31,7 +31,6 @@ function socialShareTracking(block) {
         },
       },
     }, e);
-
   });
 }
 

--- a/aemeds/blocks/social-share/social-share.js
+++ b/aemeds/blocks/social-share/social-share.js
@@ -15,16 +15,16 @@ function socialShareTracking(block) {
     }
     if (!button) return;
 
-    const section = `${analyticsCanonicStr(document.querySelector('h1')?.textContent)}:sharethis-link`;
-    const ctaText = button.getAttribute('data-network');
+    const section = analyticsCanonicStr(document.querySelector('h1')?.textContent);
+    const ctaText = `sharethis-link:${button.getAttribute('data-network')}`;
 
     analyticsGlobalClickTrack({
       event: {
-        pageArea: 'social-sharing',
+        pageArea: 'body',
         eVar22: ctaText,
         click: {
           componentName: block.classList[0],
-          pageArea: 'social-sharing',
+          pageArea: 'body',
           section,
           ctaText,
           destination: window.location.href,

--- a/aemeds/blocks/social-share/social-share.js
+++ b/aemeds/blocks/social-share/social-share.js
@@ -9,27 +9,29 @@ const esdCutOff = new Date('2024-04-16'); // 16 April 2024
 
 function socialShareTracking(block) {
   block.addEventListener('click', (e) => {
-    const button = e.target.parentElement;
-    console.log(button);
-
-    if (button.classList.contains('st-btn')) {
-      const section = analyticsCanonicStr(document.querySelector('h1')?.textContent);
-      const networkLabel = button.getAttribute('data-network');
-      const ctaText = `sharethis-link:${networkLabel}`;
-
-      analyticsGlobalClickTrack({
-        event: {
-          pageArea: 'social-sharing',
-          eVar22: ctaText,
-          click: {
-            componentName: block.classList[0],
-            pageArea: 'social-sharing',
-            section,
-            ctaText,
-          },
-        },
-      }, e);
+    let button = e.target;
+    if (!button.classList.contains('st-btn')) {
+      button = button.closest('.st-btn');
     }
+    if (!button) return;
+
+    const section = analyticsCanonicStr(document.querySelector('h1')?.textContent);
+    const networkLabel = button.getAttribute('data-network');
+    const ctaText = `sharethis-link:${networkLabel}`;
+
+    analyticsGlobalClickTrack({
+      event: {
+        pageArea: 'social-sharing',
+        eVar22: ctaText,
+        click: {
+          componentName: block.classList[0],
+          pageArea: 'social-sharing',
+          section,
+          ctaText,
+        },
+      },
+    }, e);
+
   });
 }
 

--- a/aemeds/blocks/social-share/social-share.js
+++ b/aemeds/blocks/social-share/social-share.js
@@ -15,16 +15,17 @@ function socialShareTracking(block) {
     if (button.classList.contains('st-btn')) {
       const section = analyticsCanonicStr(document.querySelector('h1')?.textContent);
       const networkLabel = button.getAttribute('data-network');
+      const ctaText = `sharethis-link:${networkLabel}`;
 
       analyticsGlobalClickTrack({
         event: {
           pageArea: 'social-sharing',
-          eVar22: `sharethis-link:${networkLabel}`,
-          eVar30: getAnalyticsSiteName(),
+          eVar22: ctaText,
           click: {
             componentName: block.classList[0],
             pageArea: 'social-sharing',
             section,
+            ctaText,
           },
         },
       }, e);

--- a/aemeds/blocks/social-share/social-share.js
+++ b/aemeds/blocks/social-share/social-share.js
@@ -27,6 +27,7 @@ function socialShareTracking(block) {
           pageArea: 'social-sharing',
           section,
           ctaText,
+          destination: window.location.href,
         },
       },
     }, e);

--- a/aemeds/scripts/scripts.js
+++ b/aemeds/scripts/scripts.js
@@ -56,7 +56,6 @@ export function analyticsGlobalClickTrack(digitalData, event) {
   };
 
   window.appEventData.push(data);
-  console.log(data);
 }
 
 export async function fetchAPI(path) {

--- a/aemeds/scripts/scripts.js
+++ b/aemeds/scripts/scripts.js
@@ -56,6 +56,7 @@ export function analyticsGlobalClickTrack(digitalData, event) {
   };
 
   window.appEventData.push(data);
+  console.log('appEventData', data);
 }
 
 export async function fetchAPI(path) {

--- a/aemeds/scripts/scripts.js
+++ b/aemeds/scripts/scripts.js
@@ -56,7 +56,7 @@ export function analyticsGlobalClickTrack(digitalData, event) {
   };
 
   window.appEventData.push(data);
-  console.log('appEventData', data);
+  console.log(data);
 }
 
 export async function fetchAPI(path) {


### PR DESCRIPTION
Click Track events are only sent if the `ctaText` and `destination` are also present.

Fix: #123

Test URLs:
With Launch
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2024/unique-career-growth-plan
- After: https://socialclicktrack--servicenow--hlxsites.hlx.live/blogs/2024/unique-career-growth-plan

With Launch Disabled
- Before: https://main--servicenow--hlxsites.hlx.live/blogs/2024/unique-career-growth-plan?disableLaunch=true
- After: https://socialclicktrack--servicenow--hlxsites.hlx.live/blogs/2024/unique-career-growth-plan?disableLaunch=true