### PR TITLE
fix: Tradeoff - Load Adobe Launch in head if cached

### DIFF
--- a/aemeds/scripts/delayed.js
+++ b/aemeds/scripts/delayed.js
@@ -4,3 +4,8 @@ import { sampleRUM } from './aem.js';
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 // add more delayed functionality here
+
+if (!window.sessionStorage.getItem('adobeLaunchCached')) {
+  loadAdobeDTM();
+  sessionStorage.setItem('adobeLaunchCached', 'true');
+}

--- a/head.html
+++ b/head.html
@@ -61,5 +61,7 @@
     }
   }
 
-  loadAdobeDTM();
+  if (sessionStorage.getItem('adobeLaunchCached')) {
+    loadAdobeDTM();
+  }
 </script>


### PR DESCRIPTION
Proposal: Load Adobe Launch Script in the head, as long as the scripts are cached in the local browser. Otherwise, load them delayed.

Test URLs:
- Before: https://main--servicenow--hlxsites.hlx.live/blogs
- After: https://dtmtradeoff--servicenow--hlxsites.hlx.live/blogs
