### PR TITLE
25 - 404 Handler: Improvement

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,12 +4,25 @@
 <head>
   <meta charset="UTF-8">
   <title>Page not found</title>
+  <style>
+    #snow-error-frame {
+      overflow: hidden;
+      overflow-x: hidden;
+      overflow-y: hidden;
+      height: 100%;
+      width: 100%;
+      position: absolute;
+      top: 0px;
+      left: 0px;
+      right: 0px;
+      bottom: 0px;
+    }
+  </style>
   <script type="text/javascript">
     window.isErrorPage = true;
     window.errorCode = '404';
     document.addEventListener('DOMContentLoaded', function () {
       const path = window.location.pathname;
-
       let locale = '';
 
       const match = path.match(/^\/(uk|de|fr|nl)\//);
@@ -17,8 +30,16 @@
         locale = `/${match[1]}`;
       }
       const snowErrorPage = `https://servicenow.com${locale}/page-not-found.html`;
-
-      window.location.href = snowErrorPage;
+      if (window.location.pathname.endsWith('/test404') && // canary to test in the prod domain
+        (window.location.hostname.endsWith('.servicenow.com') || window.location.hostname === 'servicenow.com')) {
+        document.body.innerHTML = '';
+        const iframe = document.createElement('iframe');
+        iframe.id = 'snow-error-frame';
+        iframe.src = snowErrorPage;
+        document.body.appendChild(iframe);
+      } else {
+        window.location.href = snowErrorPage;
+      }
     });
   </script>
 </head>


### PR DESCRIPTION
Fix #25

The Content Security Policy from servicenow.com doesn't allow adding iframes for the `.live` and `.page` domains, but that doesn't prevent us from creating the iframe in production.

This PR when merged will introduce a canary logic so we can test in production if iframeing the 404 page would work, thus allowing us not to change the window location.